### PR TITLE
Allow the plugin to be located anywhere

### DIFF
--- a/ide-mode-run.js
+++ b/ide-mode-run.js
@@ -2,7 +2,12 @@ var actions = require('./ide-mode-actions.js');
 var fs = require('fs');
 
 var stdinBuffer = fs.readFileSync(0);
-var [command, file, selection, line, column] = stdinBuffer.toString().split('\n');
+
+var command    = process.env["kak_idris_command"];
+var file       = process.env["kak_idris_file"];
+var selection  = process.env["kak_idris_selection"];
+var line       = process.env["kak_idris_line"];
+var column     = process.env["kak_idris_column"];
 
 var action = actions[command];
 

--- a/ide-mode-test.js
+++ b/ide-mode-test.js
@@ -11,7 +11,7 @@ var testNonExistingSrc = path.join(testDir, 'NonExisting.idr');
 
 // clear build directory to prevent change in idris compiler
 // version from breaking tests
-fs.rmdirSync('build', { recursive: true });
+try{ fs.rmdirSync('build', { recursive: true }); } catch (e) {}
 
 
 // We need to preload the files to have deterministic messages later

--- a/idris.kak
+++ b/idris.kak
@@ -1,6 +1,12 @@
 # http://idris.org
 # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
+# Configuration
+# ‾‾‾‾‾‾‾‾‾
+
+declare-option -docstring 'path to the folder containing the nodejs implementation of the plugin' \
+    str idris_implementation_root %sh{dirname "$kak_source"}
+
 # Detection
 # ‾‾‾‾‾‾‾‾‾
 
@@ -39,8 +45,13 @@ define-command -hidden idris-ide-inner-word -params 0 %{
 define-command -docstring 'Invoke Idris IDE command' idris-ide -params 1 %{
     write
 	eval %sh{
-    	printf "$1\n$kak_buffile\n$kak_selection\n$kak_cursor_line\n$kak_cursor_char_column" |
-    	node ~/.kakoune-idris/ide-mode-run.js
+    	export kak_idris_command="$1"
+    	export kak_idris_file="$kak_buffile"
+    	export kak_idris_selection="$kak_selection"
+    	export kak_idris_line="$kak_cursor_line"
+    	export kak_idris_column="$kak_cursor_char_column"
+
+    	node "$kak_opt_idris_implementation_root/ide-mode-run.js"
 	}
 }
 


### PR DESCRIPTION
Hey! I've been wishing for kakoune support for idris for a long time! This is really cool.

This PR checks where the idris.kak is located and looks for the nodejs files in the same folder.

(It also experiments with a different way to pass parameters to the nodejs script)