### PR TITLE
Fix case splitting on the final line of a file

### DIFF
--- a/ide-mode-actions.js
+++ b/ide-mode-actions.js
@@ -67,7 +67,7 @@ exports.typeOf = function(file, ipkg, root, selection, line, column) {
 exports.caseSplit = function(file, ipkg, root, selection, line, column) {
     return idrisExec(file, ipkg, root, `((:case-split ${line} "${selection}") 1)`, exprs => {
         let generatedCode = lastRetVal(exprs);
-        return `execute-keys -draft x c "${newLinesToRet(generatedCode)}<ret><esc>"; execute-keys ${line}g ${column - 1}l`;
+        return `execute-keys -draft g h G l d i "${newLinesToRet(generatedCode)}<esc>"; execute-keys ${line}g ${column - 1}l`;
     });
     
 }


### PR DESCRIPTION
If we case split on the `xs` of this function when at the end of a file:

```idris
test : List a -> Nat
test xs = ?test_rhs
```

We end up with this:

```idris
test : List a -> Nattest [] = ?test_rhs_1
test (x :: xs) = ?test_rhs_2
```

We fix this by not using `c` to delete the current line.