### PR TITLE
avoid polluting history and changing selections

### DIFF
--- a/idris.kak
+++ b/idris.kak
@@ -32,8 +32,8 @@ hook global BufCreate .*[.](idr|blod) %{
 
 declare-user-mode idris-ide
 
-map global idris-ide i ': eval -draft %{ idris-ide interpret }<ret>' -docstring 'interpret'
-map global idris-ide t ': eval -draft %{ idris-ide-inner-word; idris-ide typeOf }<ret>' -docstring 'type-of'
+map global idris-ide i ': idris-ide interpret<ret>' -docstring 'interpret'
+map global idris-ide t ': idris-ide-inner-word; idris-ide typeOf<ret>' -docstring 'type-of'
 map global idris-ide a ': eval -draft %{ idris-ide-inner-word; idris-ide addClause }<ret>' -docstring 'add-clause'
 map global idris-ide s ': eval -draft %{ idris-ide-inner-word; idris-ide caseSplit }<ret>' -docstring 'case-split'
 map global idris-ide p ': eval -draft %{ idris-ide-inner-word; idris-ide proofSearch }<ret>' -docstring 'proof-search'

--- a/idris.kak
+++ b/idris.kak
@@ -32,14 +32,14 @@ hook global BufCreate .*[.](idr|blod) %{
 
 declare-user-mode idris-ide
 
-map global idris-ide i ':idris-ide interpret<ret>' -docstring 'interpret'
-map global idris-ide t ':idris-ide-inner-word; idris-ide typeOf<ret>' -docstring 'type-of'
-map global idris-ide a ':idris-ide-inner-word; idris-ide addClause<ret>' -docstring 'add-clause'
-map global idris-ide s ':idris-ide-inner-word; idris-ide caseSplit<ret>' -docstring 'case-split'
-map global idris-ide p ':idris-ide-inner-word; idris-ide proofSearch<ret>' -docstring 'proof-search'
-map global idris-ide d ':idris-ide-inner-word; idris-ide generateDef<ret>' -docstring 'generate-def'
-map global idris-ide l ':idris-ide-inner-word; idris-ide makeLemma<ret>' -docstring 'make-lemma'
-map global idris-ide w ':idris-ide-inner-word; idris-ide makeWith<ret>' -docstring 'make-with'
+map global idris-ide i ': eval -draft %{ idris-ide interpret }<ret>' -docstring 'interpret'
+map global idris-ide t ': eval -draft %{ idris-ide-inner-word; idris-ide typeOf }<ret>' -docstring 'type-of'
+map global idris-ide a ': eval -draft %{ idris-ide-inner-word; idris-ide addClause }<ret>' -docstring 'add-clause'
+map global idris-ide s ': eval -draft %{ idris-ide-inner-word; idris-ide caseSplit }<ret>' -docstring 'case-split'
+map global idris-ide p ': eval -draft %{ idris-ide-inner-word; idris-ide proofSearch }<ret>' -docstring 'proof-search'
+map global idris-ide d ': eval -draft %{ idris-ide-inner-word; idris-ide generateDef }<ret>' -docstring 'generate-def'
+map global idris-ide l ': eval -draft %{ idris-ide-inner-word; idris-ide makeLemma }<ret>' -docstring 'make-lemma'
+map global idris-ide w ': eval -draft %{ idris-ide-inner-word; idris-ide makeWith }<ret>' -docstring 'make-with'
 
 define-command -hidden idris-ide-inner-word -params 0 %{
     execute-keys <A-i> w


### PR DESCRIPTION
I noticed that after I run commands through the `idris-ide` user mode, both my selection history and command history have new things in them. If we prepend a space to the command, and run in `-draft` context we can avoid adding scripted changes to both of these.